### PR TITLE
adjust text2vec prune_vocabulary parameter name

### DIFF
--- a/code/featurization.R
+++ b/code/featurization.R
@@ -49,7 +49,7 @@ tok_fun = word_tokenizer
 it_train = itoken(df_train$text,  preprocessor = prep_fun,  tokenizer = tok_fun,  ids = df_train$ID, progressbar = FALSE)
 vocab = create_vocabulary(it_train,stopwords = stop_words)
 
-pruned_vocab <- prune_vocabulary(vocab, max_number_of_terms=5000)
+pruned_vocab <- prune_vocabulary(vocab, vocab_term_max=5000)
 
 #str(vocab$vocab$terms)
 #str(pruned_vocab$vocab$terms_counts)


### PR DESCRIPTION
Tested with text2vec 0.5.1.

* https://cran.r-project.org/web/packages/text2vec/text2vec.pdf#page=25

The error I got was:

```
$ Rscript --vanilla code/featurization.R data/train_post.csv \
     data/test_post.csv data/matrix_train.txt data/matrix_test.txt
Loading required package: methods
Error in prune_vocabulary(vocab, max_number_of_terms = 5000) :
  unused argument (max_number_of_terms = 5000)
Execution halted
```